### PR TITLE
use `#[panic_handler]` instead of `#[panic_implementation]`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: nightly
-      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
     - env: TARGET=thumbv7m-none-eabi
       rust: nightly
@@ -37,6 +36,9 @@ install:
 
 script:
   - bash ci/script.sh
+
+after_success:
+  - bash ci/after-success.sh
 
 after_script: set +e
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.1] - 2018-09-03
+
+### Changed
+
+- This crate no longer depends on `arm-none-eabi-gcc`.
+
+- Move from the `panic_implementation` attribute to the `panic_handler`
+  attribute, which will be stabilized.
+
 ## [v0.2.0] - 2018-06-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.2.1] - 2018-09-03
+## [v0.3.0] - 2018-09-03
 
 ### Changed
 
 - This crate no longer depends on `arm-none-eabi-gcc`.
 
-- Move from the `panic_implementation` attribute to the `panic_handler`
-  attribute, which will be stabilized.
+- [breaking-change] Move from the `panic_implementation` attribute to the
+  `panic_handler` attribute, which will be stabilized.
 
 ## [v0.2.0] - 2018-06-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,12 @@
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
 categories = ["no-std"]
 description = "Log panic messages using the ITM (Instrumentation Trace Macrocell)"
+documentation = "https://rust-embedded.github.io/panic-itm/panic_itm"
 keywords = ["panic-impl", "panic", "ITM", "ARM", "Cortex-M"]
 license = "MIT OR Apache-2.0"
 name = "panic-itm"
-repository = "https://github.com/japaric/panic-itm"
-version = "0.2.0"
+repository = "https://github.com/rust-embedded/panic-itm"
+version = "0.2.1"
 
 [dependencies]
-cortex-m = "0.5.0"
+cortex-m = "0.5.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["panic-impl", "panic", "ITM", "ARM", "Cortex-M"]
 license = "MIT OR Apache-2.0"
 name = "panic-itm"
 repository = "https://github.com/rust-embedded/panic-itm"
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies]
 cortex-m = "0.5.6"

--- a/ci/after-success.sh
+++ b/ci/after-success.sh
@@ -1,0 +1,20 @@
+set -euxo pipefail
+
+main() {
+    cargo doc
+
+    mkdir ghp-import
+
+    curl -Ls https://github.com/davisp/ghp-import/archive/master.tar.gz |
+        tar --strip-components 1 -C ghp-import -xz
+
+    ./ghp-import/ghp_import.py target/doc
+
+    set +x
+    git push -fq https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG.git gh-pages && echo OK
+}
+
+# only publish on successful merges to master
+if [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ] && [ $TARGET = x86_64-unknown-linux-gnu ]; then
+    main
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,18 +30,19 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(panic_implementation)]
+#![feature(panic_handler)]
 #![no_std]
 
 #[macro_use]
 extern crate cortex_m;
 
 use core::panic::PanicInfo;
+use core::sync::atomic::{self, Ordering};
 
 use cortex_m::peripheral::ITM;
 use cortex_m::interrupt;
 
-#[panic_implementation]
+#[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     interrupt::disable();
 
@@ -50,5 +51,9 @@ fn panic(info: &PanicInfo) -> ! {
 
     iprintln!(stim, "{}", info);
 
-    loop {}
+    loop {
+        // add some side effect to prevent this from turning into a UDF instruction
+        // see rust-lang/rust#28728 for details
+        atomic::compiler_fence(Ordering::SeqCst)
+    }
 }


### PR DESCRIPTION
the later has been deprecated.

`panic_implementation` was deprecated in today's nightly but existing builds
won't break (they'll just get an extra warning).

Do not merge this just yet because that will break builds that haven't move to
the latest nightly. We should merge this in one week or so to not break people
that don't often update their nightly compiler.

This PR also puts our docs on GH pages because docs.rs won't be able to build
the docs after this change.

cc @rust-embedded/cortex-m