### PR TITLE
remove `panic_handler` feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.4.0] - 2018-09-10
+
+- [breaking-change] The `panic_handler` feature gate has been removed. This
+  crate will compile on 1.30-beta and on stable 1.30 when they are released.
+
 ## [v0.3.0] - 2018-09-03
 
 ### Changed
@@ -36,6 +41,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/japaric/panic-itm/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/japaric/panic-itm/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/japaric/panic-itm/compare/v0.3.0...v0.4.0
+[v0.3.0]: https://github.com/japaric/panic-itm/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/japaric/panic-itm/compare/v0.1.1...v0.2.0
 [v0.1.1]: https://github.com/japaric/panic-itm/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ authors = ["Jorge Aparicio <jorge@japaric.io>"]
 categories = ["no-std"]
 description = "Log panic messages using the ITM (Instrumentation Trace Macrocell)"
 documentation = "https://rust-embedded.github.io/panic-itm/panic_itm"
-keywords = ["panic-impl", "panic", "ITM", "ARM", "Cortex-M"]
+keywords = ["panic-impl", "panic-handler", "ITM", "ARM", "Cortex-M"]
 license = "MIT OR Apache-2.0"
 name = "panic-itm"
 repository = "https://github.com/rust-embedded/panic-itm"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 cortex-m = "0.5.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(panic_handler)]
 #![no_std]
 
 #[macro_use]


### PR DESCRIPTION
This crate will compile on 1.30-beta and on stable 1.30 when they are released.

r? @rust-embedded/cortex-m (anyone)